### PR TITLE
Enforce sdk version 1.5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN cd /opt && git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
 RUN chmod 777 -R /opt/esp-open-sdk
 
 USER espbuilder
-RUN cd /opt/esp-open-sdk && make STANDALONE=y
+RUN cd /opt/esp-open-sdk && sed -i "/^VENDOR_SDK\s=\s.*$/VENDOR_SDK = 1.5.4/" Makefile && make STANDALONE=y
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN cd /opt && git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
 RUN chmod 777 -R /opt/esp-open-sdk
 
 USER espbuilder
-RUN cd /opt/esp-open-sdk && sed -i "/^VENDOR_SDK\s=\s.*$/VENDOR_SDK = 1.5.4/" Makefile && make STANDALONE=y
+RUN cd /opt/esp-open-sdk && sed -i "s/^VENDOR_SDK\s=\s.*$/VENDOR_SDK = 1.5.4/" Makefile && make STANDALONE=y
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN cd /opt && git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
 RUN chmod 777 -R /opt/esp-open-sdk
 
 USER espbuilder
-RUN cd /opt/esp-open-sdk && sed -i "s/^VENDOR_SDK\s=\s.*$/VENDOR_SDK = 1.5.4/" Makefile && make STANDALONE=y
+RUN cd /opt/esp-open-sdk && make VENDOR_SDK=1.5.4 STANDALONE=y
 
 USER root
 


### PR DESCRIPTION
As of esp-open-sdk's commit 24f10eb164947fdd38b6225f72e752d5eb785391 2 weeks ago, default sdk version was bumped from version 1.5.4 to 2.0.0 which is not working correctly with Sming yet, see issue #786 (https://github.com/SmingHub/Sming/issues/786).

So this patch enforces version 1.5.4 of the SDK which is working fine.